### PR TITLE
Update JDK to Amazon Corretto 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 17
+          java-version: 21
           distribution: corretto
           cache: gradle
 
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.3.2
+          gradle-version: 8.7
 
       - name: Logging into Kontur Nexus
         env:

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.14.RELEASE'
     id 'java'
     id 'jacoco'
-    id 'io.freefair.lombok' version '6.3.0'
     id 'com.google.cloud.tools.jib' version '3.3.0'
     id 'de.undercouch.download' version '5.1.2'
     id 'io.sentry.jvm.gradle' version '4.3.0'
@@ -11,7 +10,8 @@ plugins {
 
 group = 'io.kontur'
 version = '1.16.0'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
+targetCompatibility = '21'
 String imageTag = System.getenv("IMAGE_TAG") ?: 'latest'
 
 repositories {
@@ -32,6 +32,10 @@ sentry {
 }
 
 dependencies {
+    //lombok
+    annotationProcessor 'org.projectlombok:lombok:1.18.32'
+    compileOnly 'org.projectlombok:lombok:1.18.32'
+
     //model
     implementation 'org.wololo:jts2geojson:0.18.1'
     implementation 'org.locationtech.jts.io:jts-io-common:1.19.0'
@@ -91,7 +95,7 @@ test {
 
 jacocoTestReport {
     reports {
-        csv.enabled true
+        csv.required = true
         csv.destination file("${buildDir}/jacoco.csv")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Updated Java version from 17 to 21 in the workflow configuration and `build.gradle` file.
    - Added default `imageTag` value in `build.gradle` if not provided via environment variables.
    - Updated Gradle version from 7.3.2 to 8.7 in the workflow configuration and `gradle-wrapper.properties`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->