### PR TITLE
Improve error handling

### DIFF
--- a/src/main/java/io/kontur/layers/controller/CollectionsApi.java
+++ b/src/main/java/io/kontur/layers/controller/CollectionsApi.java
@@ -42,7 +42,8 @@ public class CollectionsApi {
     @Operation(summary = "describe the feature collection with id `collectionId`", description = "", tags = {"Capabilities"})
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "Information about the feature collection with id `collectionId`.  The response contains a linkto the items in the collection (path `/collections/{collectionId}/items`,link relation `items`) as well as key information about the collection. This information includes:  * A local identifier for the collection that is unique for the dataset; * A list of coordinate reference systems (CRS) in which geometries may be returned by the server. The first CRS is the default coordinate reference system (the default is always WGS 84 with axis order longitude/latitude); * An optional title and description for the collection; * An optional extent that can be used to provide an indication of the spatial and temporal extent of the collection - typically derived from the data; * An optional indicator about the type of the items in the collection (the default value, if the indicator is not provided, is 'feature').", content = @Content(schema = @Schema(implementation = Collection.class))),
-            @ApiResponse(responseCode = "404", description = "The requested URI was not found."),
+            @ApiResponse(responseCode = "403", description = "Access is forbidden.", content = @Content(schema = @Schema(implementation = Error.class))),
+            @ApiResponse(responseCode = "404", description = "The requested URI was not found.", content = @Content(schema = @Schema(implementation = Error.class))),
             @ApiResponse(responseCode = "500", description = "A server error occurred.", content = @Content(schema = @Schema(implementation = Exception.class)))})
     public ResponseEntity describeCollection(
             @Parameter(in = ParameterIn.PATH, description = "local identifier of a collection", required = true)

--- a/src/main/java/io/kontur/layers/controller/exceptions/RestResponseEntityExceptionHandler.java
+++ b/src/main/java/io/kontur/layers/controller/exceptions/RestResponseEntityExceptionHandler.java
@@ -70,7 +70,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
         if (ex.getCause() instanceof MismatchedInputException) {
             fieldName = getInvalidFormatExceptionFieldName((MismatchedInputException) ex.getCause());
         } else if (ex.getCause() instanceof JsonParseException) {
-            return new ResponseEntity<>(Error.error(ex.getCause().getMessage()), BAD_REQUEST);
+            return new ResponseEntity<>(Error.error("body is not valid JSON"), BAD_REQUEST);
         }
         return new ResponseEntity<>(Error.objectError(null, Error.fieldError(fieldName, Error.error(msg))),
                 BAD_REQUEST);
@@ -93,7 +93,7 @@ public class RestResponseEntityExceptionHandler extends ResponseEntityExceptionH
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex, WebRequest request) {
-        return new ResponseEntity<>(Error.error(ex.getMessage()), UNAUTHORIZED);
+        return new ResponseEntity<>(Error.error(ex.getMessage()), FORBIDDEN);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/io/kontur/layers/repository/LayerMapper.java
+++ b/src/main/java/io/kontur/layers/repository/LayerMapper.java
@@ -81,4 +81,7 @@ public interface LayerMapper {
     @Timed(value = "db.query", histogram = true)
     List<Layer> getApplicationLayers(@Param("appId") UUID appId,
                                      @Param("getDefaultOnly") boolean getDefaultOnly);
+
+    @Timed(value = "db.query", histogram = true)
+    boolean layerExists(@Param("publicId") String publicId);
 }

--- a/src/main/java/io/kontur/layers/service/CollectionService.java
+++ b/src/main/java/io/kontur/layers/service/CollectionService.java
@@ -103,8 +103,16 @@ public class CollectionService {
 
     @Transactional(readOnly = true)
     public Optional<Collection> getCollection(String collectionId) {
-        return layerMapper.getLayer(collectionId, AuthorizationUtils.getAuthenticatedUserName())
-                .map(this::toCollection);
+        String userName = AuthorizationUtils.getAuthenticatedUserName();
+        Optional<Layer> layer = layerMapper.getLayer(collectionId, userName);
+        if (layer.isEmpty()) {
+            if (userName == null && layerMapper.layerExists(collectionId)) {
+                throw new WebApplicationException(HttpStatus.FORBIDDEN,
+                        Error.error("access forbidden"));
+            }
+            return Optional.empty();
+        }
+        return layer.map(this::toCollection);
     }
 
     @Transactional

--- a/src/main/resources/db/mappers/LayerMapper.xml
+++ b/src/main/resources/db/mappers/LayerMapper.xml
@@ -388,4 +388,8 @@
                     </if>
               );
     </select>
+
+    <select id="layerExists" resultType="boolean">
+        select exists(select 1 from layers where public_id = #{publicId} and is_visible)
+    </select>
 </mapper>

--- a/src/test/java/io/kontur/layers/controller/CollectionsGetIT.java
+++ b/src/test/java/io/kontur/layers/controller/CollectionsGetIT.java
@@ -176,6 +176,21 @@ public class CollectionsGetIT extends AbstractIntegrationTest {
     }
 
     @Test
+    @DisplayName("private collection without auth should respond with 403")
+    public void privateCollectionWithoutAuth() throws Exception {
+        //GIVEN
+        final Layer layer = buildLayerN(2);
+        layer.setPublic(false);
+        testDataMapper.insertLayer(layer);
+
+        //WHEN THEN
+        mockMvc.perform(get("/collections/" + layer.getPublicId()))
+                .andDo(print())
+                .andExpect(status().isForbidden())
+                .andExpect(content().contentType(APPLICATION_JSON));
+    }
+
+    @Test
     @DisplayName("url to tiles is present for tiles layers")
     public void returnLinkToTiles_8626() throws Exception {
         //GIVEN

--- a/src/test/java/io/kontur/layers/controller/CollectionsItemsDeleteIT.java
+++ b/src/test/java/io/kontur/layers/controller/CollectionsItemsDeleteIT.java
@@ -72,7 +72,7 @@ public class CollectionsItemsDeleteIT extends AbstractIntegrationTest {
         //WHEN
         mockMvc.perform(delete("/collections/whatever/items/xxx"))
                 .andDo(print())
-                .andExpect(status().isUnauthorized())
+                .andExpect(status().isForbidden())
                 .andReturn().getResponse().getContentAsString();
     }
 }

--- a/src/test/java/io/kontur/layers/controller/CollectionsPostIT.java
+++ b/src/test/java/io/kontur/layers/controller/CollectionsPostIT.java
@@ -307,7 +307,7 @@ public class CollectionsPostIT extends AbstractIntegrationTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(JsonUtil.writeJson(collection)))
                 .andDo(print())
-                .andExpect(status().isUnauthorized())
+                .andExpect(status().isForbidden())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andReturn().getResponse().getContentAsString();
     }


### PR DESCRIPTION
## Summary
- add database check for collection existence and return 403 when private collection requested anonymously
- make access-denied handler return 403
- show a helpful message for invalid JSON bodies
- document 403 response in openapi annotations
- update integration tests

## Testing
- `gradle test` *(fails: Plugin org.springframework.boot not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messaging for invalid JSON input, now returning a clear "body is not valid JSON" message.
  - Changed unauthorized access responses from HTTP 401 to HTTP 403 for certain endpoints, providing more accurate status codes.

- **New Features**
  - Enhanced API error documentation for collection endpoints, clarifying expected error responses.
  - Added stricter access checks for private collections, returning HTTP 403 when accessed without authentication.

- **Tests**
  - Added and updated integration tests to verify correct HTTP 403 Forbidden responses for unauthorized access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->