### PR TITLE
Add basic private layer access

### DIFF
--- a/src/main/java/io/kontur/layers/controller/CollectionsApi.java
+++ b/src/main/java/io/kontur/layers/controller/CollectionsApi.java
@@ -125,4 +125,20 @@ public class CollectionsApi {
         collectionService.deleteCollection(collectionId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @PutMapping("/{collectionId}/access/{userName}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity grantAccess(@PathVariable("collectionId") String collectionId,
+                                      @PathVariable("userName") String userName) {
+        collectionService.grantAccess(collectionId, userName);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{collectionId}/access/{userName}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity revokeAccess(@PathVariable("collectionId") String collectionId,
+                                       @PathVariable("userName") String userName) {
+        collectionService.revokeAccess(collectionId, userName);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/io/kontur/layers/repository/LayerAccessMapper.java
+++ b/src/main/java/io/kontur/layers/repository/LayerAccessMapper.java
@@ -1,0 +1,20 @@
+package io.kontur.layers.repository;
+
+import io.micrometer.core.annotation.Timed;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Delete;
+
+@Mapper
+@Timed(value = "db.query", histogram = true)
+public interface LayerAccessMapper {
+
+    @Timed(value = "db.query", histogram = true)
+    @Insert("INSERT INTO layers_access (layer_id, user_name) VALUES (#{layerId}, #{userName}) ON CONFLICT DO NOTHING")
+    void grantAccess(@Param("layerId") String layerId, @Param("userName") String userName);
+
+    @Timed(value = "db.query", histogram = true)
+    @Delete("DELETE FROM layers_access WHERE layer_id = #{layerId} AND user_name = #{userName}")
+    void revokeAccess(@Param("layerId") String layerId, @Param("userName") String userName);
+}

--- a/src/main/java/io/kontur/layers/service/CollectionService.java
+++ b/src/main/java/io/kontur/layers/service/CollectionService.java
@@ -9,6 +9,7 @@ import io.kontur.layers.dto.*;
 import io.kontur.layers.repository.ApplicationLayerMapper;
 import io.kontur.layers.repository.ApplicationMapper;
 import io.kontur.layers.repository.LayerMapper;
+import io.kontur.layers.repository.LayerAccessMapper;
 import io.kontur.layers.repository.model.Application;
 import io.kontur.layers.repository.model.ApplicationLayer;
 import io.kontur.layers.repository.model.Layer;
@@ -39,14 +40,17 @@ public class CollectionService {
     private final LinkFactory linkFactory;
     private final ApplicationMapper applicationMapper;
     private final ApplicationLayerMapper applicationLayerMapper;
+    private final LayerAccessMapper layerAccessMapper;
 
     public CollectionService(LayerMapper layerMapper,
                              LinkFactory linkFactory, ApplicationMapper applicationMapper,
-                             ApplicationLayerMapper applicationLayerMapper) {
+                             ApplicationLayerMapper applicationLayerMapper,
+                             LayerAccessMapper layerAccessMapper) {
         this.layerMapper = layerMapper;
         this.linkFactory = linkFactory;
         this.applicationMapper = applicationMapper;
         this.applicationLayerMapper = applicationLayerMapper;
+        this.layerAccessMapper = layerAccessMapper;
     }
 
     @Transactional(readOnly = true)
@@ -266,6 +270,16 @@ public class CollectionService {
 
         }
         return extent;
+    }
+
+    @Transactional
+    public void grantAccess(String collectionId, String userName) {
+        layerAccessMapper.grantAccess(collectionId, userName);
+    }
+
+    @Transactional
+    public void revokeAccess(String collectionId, String userName) {
+        layerAccessMapper.revokeAccess(collectionId, userName);
     }
 
     private boolean isUserOwnsLayer(Layer layer) {

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -28,3 +28,6 @@ databaseChangeLog:
   - include:
       - relativeToChangelogFile: true
       - file: v1.18/v1.18.yaml
+  - include:
+      - relativeToChangelogFile: true
+      - file: v1.19/v1.19.yaml

--- a/src/main/resources/db/changelog/v1.19/create-layer-access-table.sql
+++ b/src/main/resources/db/changelog/v1.19/create-layer-access-table.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset layers-api-migrations:create-layer-access-table.sql runOnChange:false
+
+CREATE TABLE IF NOT EXISTS layers_access
+(
+    layer_id  text NOT NULL REFERENCES layers (public_id) ON DELETE CASCADE,
+    user_name text NOT NULL,
+    PRIMARY KEY (layer_id, user_name)
+);

--- a/src/main/resources/db/changelog/v1.19/v1.19.yaml
+++ b/src/main/resources/db/changelog/v1.19/v1.19.yaml
@@ -1,0 +1,5 @@
+## Database Changelog
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-layer-access-table.sql

--- a/src/main/resources/db/mappers/LayerMapper.xml
+++ b/src/main/resources/db/mappers/LayerMapper.xml
@@ -48,10 +48,13 @@
                 and owner = #{userName}
             </when>
             <when test='collectionOwner.name().equals("NOT_ME")'>
-                and is_public and owner != #{userName}
+                and (is_public
+                     or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                and owner != #{userName}
             </when>
             <when test="userName != null">
-                and (is_public or owner = #{userName})
+                and (is_public or owner = #{userName}
+                     or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
             </when>
             <otherwise>
                 and is_public
@@ -87,10 +90,13 @@
                     and owner = #{userName}
                 </when>
                 <when test='collectionOwner.name().equals("NOT_ME")'>
-                    and is_public and owner != #{userName}
+                    and (is_public
+                         or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                    and owner != #{userName}
                 </when>
                 <when test="userName != null">
-                    and (is_public or owner = #{userName})
+                    and (is_public or owner = #{userName}
+                         or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                 </when>
                 <otherwise>
                     and is_public
@@ -133,10 +139,13 @@
                            and owner = #{userName}
                        </when>
                        <when test='collectionOwner.name().equals("NOT_ME")'>
-                           and is_public and owner != #{userName}
+                           and (is_public
+                                or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                           and owner != #{userName}
                        </when>
                        <when test="userName != null">
-                           and (is_public or owner = #{userName})
+                           and (is_public or owner = #{userName}
+                                or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                        </when>
                        <otherwise>
                            and is_public
@@ -172,10 +181,13 @@
                             and owner = #{userName}
                         </when>
                         <when test='collectionOwner.name().equals("NOT_ME")'>
-                            and is_public and owner != #{userName}
+                            and (is_public
+                                 or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                            and owner != #{userName}
                         </when>
                         <when test="userName != null">
-                            and (is_public or owner = #{userName})
+                            and (is_public or owner = #{userName}
+                                 or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                         </when>
                         <otherwise>
                             and is_public


### PR DESCRIPTION
## Summary
- support private access mapping for layers
- add endpoints to grant or revoke layer access
- patch queries for user-specific access
- track access rules in new Liquibase migration

## Testing
- `./gradlew test` *(fails: No route to host for Gradle wrapper download)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability for authenticated users to grant or revoke access to collections for specific users via new API endpoints.
- **Database**
  - Introduced a new table to manage user access permissions for layers.
  - Updated database migration scripts to support access control functionality.
- **Access Control**
  - Enhanced access logic so users can view layers if they are public, owned by the user, or explicitly shared with them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->