### PR TITLE
Add basic private layer access

### DIFF
--- a/src/main/java/io/kontur/layers/controller/CollectionsApi.java
+++ b/src/main/java/io/kontur/layers/controller/CollectionsApi.java
@@ -125,4 +125,20 @@ public class CollectionsApi {
         collectionService.deleteCollection(collectionId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @PutMapping("/{collectionId}/access/{userName}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity grantAccess(@PathVariable("collectionId") String collectionId,
+                                      @PathVariable("userName") String userName) {
+        collectionService.grantAccess(collectionId, userName);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/{collectionId}/access/{userName}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity revokeAccess(@PathVariable("collectionId") String collectionId,
+                                       @PathVariable("userName") String userName) {
+        collectionService.revokeAccess(collectionId, userName);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/io/kontur/layers/repository/LayerAccessMapper.java
+++ b/src/main/java/io/kontur/layers/repository/LayerAccessMapper.java
@@ -1,0 +1,20 @@
+package io.kontur.layers.repository;
+
+import io.micrometer.core.annotation.Timed;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Delete;
+
+@Mapper
+@Timed(value = "db.query", histogram = true)
+public interface LayerAccessMapper {
+
+    @Timed(value = "db.query", histogram = true)
+    @Insert("INSERT INTO layers_access (layer_id, user_name) VALUES (#{layerId}, #{userName}) ON CONFLICT DO NOTHING")
+    void grantAccess(@Param("layerId") String layerId, @Param("userName") String userName);
+
+    @Timed(value = "db.query", histogram = true)
+    @Delete("DELETE FROM layers_access WHERE layer_id = #{layerId} AND user_name = #{userName}")
+    void revokeAccess(@Param("layerId") String layerId, @Param("userName") String userName);
+}

--- a/src/main/java/io/kontur/layers/service/CollectionService.java
+++ b/src/main/java/io/kontur/layers/service/CollectionService.java
@@ -9,6 +9,7 @@ import io.kontur.layers.dto.*;
 import io.kontur.layers.repository.ApplicationLayerMapper;
 import io.kontur.layers.repository.ApplicationMapper;
 import io.kontur.layers.repository.LayerMapper;
+import io.kontur.layers.repository.LayerAccessMapper;
 import io.kontur.layers.repository.model.Application;
 import io.kontur.layers.repository.model.ApplicationLayer;
 import io.kontur.layers.repository.model.Layer;
@@ -39,14 +40,17 @@ public class CollectionService {
     private final LinkFactory linkFactory;
     private final ApplicationMapper applicationMapper;
     private final ApplicationLayerMapper applicationLayerMapper;
+    private final LayerAccessMapper layerAccessMapper;
 
     public CollectionService(LayerMapper layerMapper,
                              LinkFactory linkFactory, ApplicationMapper applicationMapper,
-                             ApplicationLayerMapper applicationLayerMapper) {
+                             ApplicationLayerMapper applicationLayerMapper,
+                             LayerAccessMapper layerAccessMapper) {
         this.layerMapper = layerMapper;
         this.linkFactory = linkFactory;
         this.applicationMapper = applicationMapper;
         this.applicationLayerMapper = applicationLayerMapper;
+        this.layerAccessMapper = layerAccessMapper;
     }
 
     @Transactional(readOnly = true)
@@ -266,6 +270,27 @@ public class CollectionService {
 
         }
         return extent;
+    }
+
+    @Transactional
+    public void grantAccess(String collectionId, String userName) {
+        assertCanModifyAccess(collectionId);
+        layerAccessMapper.grantAccess(collectionId, userName);
+    }
+
+    @Transactional
+    public void revokeAccess(String collectionId, String userName) {
+        assertCanModifyAccess(collectionId);
+        layerAccessMapper.revokeAccess(collectionId, userName);
+    }
+
+    private void assertCanModifyAccess(String layerId) {
+        String currentUser = AuthorizationUtils.getAuthenticatedUserName();
+        boolean owner = layerMapper.getOwnedLayer(layerId, currentUser).isPresent();
+        if (!owner && !AuthorizationUtils.isSuperAdmin()) {
+            throw new WebApplicationException(HttpStatus.FORBIDDEN,
+                    "Only owner or superadmin can modify access");
+        }
     }
 
     private boolean isUserOwnsLayer(Layer layer) {

--- a/src/main/java/io/kontur/layers/util/AuthorizationUtils.java
+++ b/src/main/java/io/kontur/layers/util/AuthorizationUtils.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.GrantedAuthority;
 
 public class AuthorizationUtils {
 
@@ -29,6 +30,23 @@ public class AuthorizationUtils {
                         authentication.getPrincipal().getClass().getName()));
                 throw new WebApplicationException(HttpStatus.INTERNAL_SERVER_ERROR, Error.error("Can't authorize"));
         }
+    }
+
+    public static boolean hasRole(String role) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated() || authentication instanceof AnonymousAuthenticationToken) {
+            return false;
+        }
+        for (GrantedAuthority authority : authentication.getAuthorities()) {
+            if (role.equalsIgnoreCase(authority.getAuthority())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static boolean isSuperAdmin() {
+        return hasRole("superadmin") || hasRole("ROLE_SUPERADMIN");
     }
 
 }

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -28,3 +28,6 @@ databaseChangeLog:
   - include:
       - relativeToChangelogFile: true
       - file: v1.18/v1.18.yaml
+  - include:
+      - relativeToChangelogFile: true
+      - file: v1.19/v1.19.yaml

--- a/src/main/resources/db/changelog/v1.19/create-layer-access-table.sql
+++ b/src/main/resources/db/changelog/v1.19/create-layer-access-table.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+
+--changeset layers-api-migrations:create-layer-access-table.sql runOnChange:false
+
+CREATE TABLE IF NOT EXISTS layers_access
+(
+    layer_id  text NOT NULL REFERENCES layers (public_id) ON DELETE CASCADE,
+    user_name text NOT NULL,
+    PRIMARY KEY (layer_id, user_name)
+);

--- a/src/main/resources/db/changelog/v1.19/v1.19.yaml
+++ b/src/main/resources/db/changelog/v1.19/v1.19.yaml
@@ -1,0 +1,5 @@
+## Database Changelog
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-layer-access-table.sql

--- a/src/main/resources/db/mappers/LayerMapper.xml
+++ b/src/main/resources/db/mappers/LayerMapper.xml
@@ -48,10 +48,13 @@
                 and owner = #{userName}
             </when>
             <when test='collectionOwner.name().equals("NOT_ME")'>
-                and is_public and owner != #{userName}
+                and (is_public
+                     or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                and owner != #{userName}
             </when>
             <when test="userName != null">
-                and (is_public or owner = #{userName})
+                and (is_public or owner = #{userName}
+                     or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
             </when>
             <otherwise>
                 and is_public
@@ -87,10 +90,13 @@
                     and owner = #{userName}
                 </when>
                 <when test='collectionOwner.name().equals("NOT_ME")'>
-                    and is_public and owner != #{userName}
+                    and (is_public
+                         or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                    and owner != #{userName}
                 </when>
                 <when test="userName != null">
-                    and (is_public or owner = #{userName})
+                    and (is_public or owner = #{userName}
+                         or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                 </when>
                 <otherwise>
                     and is_public
@@ -133,10 +139,13 @@
                            and owner = #{userName}
                        </when>
                        <when test='collectionOwner.name().equals("NOT_ME")'>
-                           and is_public and owner != #{userName}
+                           and (is_public
+                                or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                           and owner != #{userName}
                        </when>
                        <when test="userName != null">
-                           and (is_public or owner = #{userName})
+                           and (is_public or owner = #{userName}
+                                or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                        </when>
                        <otherwise>
                            and is_public
@@ -172,10 +181,13 @@
                             and owner = #{userName}
                         </when>
                         <when test='collectionOwner.name().equals("NOT_ME")'>
-                            and is_public and owner != #{userName}
+                            and (is_public
+                                 or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
+                            and owner != #{userName}
                         </when>
                         <when test="userName != null">
-                            and (is_public or owner = #{userName})
+                            and (is_public or owner = #{userName}
+                                 or exists (select 1 from layers_access la where la.layer_id = l.public_id and la.user_name = #{userName}))
                         </when>
                         <otherwise>
                             and is_public

--- a/src/test/java/io/kontur/layers/controller/CollectionsAccessIT.java
+++ b/src/test/java/io/kontur/layers/controller/CollectionsAccessIT.java
@@ -1,0 +1,83 @@
+package io.kontur.layers.controller;
+
+import io.kontur.layers.repository.TestDataMapper;
+import io.kontur.layers.repository.model.Layer;
+import io.kontur.layers.test.AbstractIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static io.kontur.layers.test.TestDataHelper.buildLayerN;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("access management for collections")
+public class CollectionsAccessIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestDataMapper testDataMapper;
+
+    @Test
+    @DisplayName("owner can grant and revoke access")
+    @WithMockUser("owner_1")
+    public void ownerCanGrantAndRevoke() throws Exception {
+        //GIVEN
+        Layer layer = buildLayerN(1);
+        ReflectionTestUtils.setField(layer, "isPublic", false);
+        testDataMapper.insertLayer(layer);
+
+        mockMvc.perform(get("/collections/" + layer.getPublicId()).with(user("pigeon")))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+
+        //WHEN
+        mockMvc.perform(put("/collections/" + layer.getPublicId() + "/access/pigeon"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        //THEN
+        mockMvc.perform(get("/collections/" + layer.getPublicId()).with(user("pigeon")))
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        //WHEN revoke
+        mockMvc.perform(delete("/collections/" + layer.getPublicId() + "/access/pigeon"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+
+        //THEN access removed
+        mockMvc.perform(get("/collections/" + layer.getPublicId()).with(user("pigeon")))
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("non owner cannot grant access")
+    @WithMockUser("stranger")
+    public void notOwnerForbidden() throws Exception {
+        Layer layer = buildLayerN(1);
+        ReflectionTestUtils.setField(layer, "isPublic", false);
+        testDataMapper.insertLayer(layer);
+
+        mockMvc.perform(put("/collections/" + layer.getPublicId() + "/access/pigeon"))
+                .andDo(print())
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("superadmin can grant access")
+    @WithMockUser(username = "admin", roles = {"SUPERADMIN"})
+    public void superAdminAllowed() throws Exception {
+        Layer layer = buildLayerN(1);
+        ReflectionTestUtils.setField(layer, "isPublic", false);
+        testDataMapper.insertLayer(layer);
+
+        mockMvc.perform(put("/collections/" + layer.getPublicId() + "/access/pigeon"))
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+}

--- a/src/test/java/io/kontur/layers/test/AbstractIntegrationTest.java
+++ b/src/test/java/io/kontur/layers/test/AbstractIntegrationTest.java
@@ -43,6 +43,6 @@ public abstract class AbstractIntegrationTest {
                 .execute(status ->
                         JdbcTestUtils.deleteFromTables(jdbcTemplate, "apps_layers", "apps",
                                 "layers", "layers_features", "layers_group_properties", "layers_category_properties",
-                                "layers_dependencies"));
+                                "layers_dependencies", "layers_access"));
     }
 }


### PR DESCRIPTION
## Summary
- support private access mapping for layers
- add endpoints to grant or revoke layer access
- patch queries for user-specific access
- track access rules in new Liquibase migration
- check owner or superadmin when managing layer access

## Testing
- `./gradlew test` *(fails: No route to host for Gradle wrapper download)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability for authenticated users to grant or revoke access to collections for specific users.
- **Database**
  - Introduced a new table to manage user access rights to layers.
  - Updated database migrations to support the new access control features.
- **Access Control**
  - Enhanced access checks to allow users with granted permissions to view and manage layers, in addition to owners and superadmins.
- **Security**
  - Improved role-based authorization checks for finer access management.
- **Testing**
  - Added integration tests to verify access granting and revoking scenarios for owners, non-owners, and superadmins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->