### PR TITLE
Add endpoint to add layer to application

### DIFF
--- a/src/main/java/io/kontur/layers/controller/ApplicationsApi.java
+++ b/src/main/java/io/kontur/layers/controller/ApplicationsApi.java
@@ -1,6 +1,7 @@
 package io.kontur.layers.controller;
 
 import io.kontur.layers.dto.ApplicationDto;
+import io.kontur.layers.dto.ApplicationLayerDto;
 import io.kontur.layers.dto.ApplicationUpdateDto;
 import io.kontur.layers.service.ApplicationService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,6 +54,20 @@ public class ApplicationsApi {
             @PathVariable("applicationId") UUID applicationId,
             @RequestBody @Valid ApplicationUpdateDto body) {
         ApplicationDto result = applicationService.updateApplication(applicationId, body);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/{applicationId}/layers")
+    @Operation(summary = "Add layer to application", tags = {"Applications"})
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Updated application.",
+                    content = @Content(schema = @Schema(implementation = ApplicationDto.class)))})
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity addLayer(
+            @Parameter(in = ParameterIn.PATH, description = "local identifier of an application", required = true)
+            @PathVariable("applicationId") UUID applicationId,
+            @RequestBody @Valid ApplicationLayerDto body) {
+        ApplicationDto result = applicationService.addLayer(applicationId, body);
         return ResponseEntity.ok(result);
     }
 

--- a/src/test/java/io/kontur/layers/controller/ApplicationLayersPostIT.java
+++ b/src/test/java/io/kontur/layers/controller/ApplicationLayersPostIT.java
@@ -1,0 +1,56 @@
+package io.kontur.layers.controller;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import io.kontur.layers.dto.ApplicationLayerDto;
+import io.kontur.layers.repository.TestDataMapper;
+import io.kontur.layers.repository.model.Application;
+import io.kontur.layers.repository.model.Layer;
+import io.kontur.layers.test.AbstractIntegrationTest;
+import io.kontur.layers.util.JsonUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import static com.jayway.jsonpath.matchers.JsonPathMatchers.hasJsonPath;
+import static io.kontur.layers.test.TestDataHelper.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("POST /apps/{id}/layers")
+public class ApplicationLayersPostIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private TestDataMapper testDataMapper;
+
+    @Test
+    @WithMockUser("owner_1")
+    public void addLayerToApplication() throws Exception {
+        //GIVEN
+        Layer layer = buildLayerN(1);
+        testDataMapper.insertLayer(layer);
+        Application application = buildApplication(1);
+        testDataMapper.insertApplication(application);
+        ApplicationLayerDto dto = buildApplicationLayerDto(layer.getPublicId(), 1);
+
+        //WHEN
+        String json = mockMvc.perform(post("/apps/" + application.getId() + "/layers")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.writeJson(dto)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andReturn().getResponse().getContentAsString();
+        //THEN
+        DocumentContext dc = JsonPath.parse(json);
+        assertThat(dc, hasJsonPath("$.id", is(application.getId().toString())));
+        assertThat(dc, hasJsonPath("$.defaultCollections", hasSize(1)));
+        assertThat(dc, hasJsonPath("$.defaultCollections[0].id", is(layer.getPublicId())));
+    }
+}


### PR DESCRIPTION
## Summary
- support adding a layer to an application via POST `/apps/{id}/layers`
- implement service logic to upsert a single layer
- test adding a layer to an existing app

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6851e0d05f3c83248aacf4441092b512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to add a new layer to an existing application via a dedicated endpoint.

- **Tests**
  - Introduced integration tests to ensure correct behavior when adding a layer to an application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->