### PR TITLE
Add index for layers_features resolution

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -28,3 +28,7 @@ databaseChangeLog:
   - include:
       - relativeToChangelogFile: true
       - file: v1.18/v1.18.yaml
+  - include:
+      - relativeToChangelogFile: true
+      - file: v1.19/v1.19.yaml
+

--- a/src/main/resources/db/changelog/v1.19/create-index-layers-features-layer-resolution.sql
+++ b/src/main/resources/db/changelog/v1.19/create-index-layers-features-layer-resolution.sql
@@ -1,0 +1,9 @@
+--liquibase formatted sql
+
+--changeset layers-api-migrations:v1.19/create-index-layers-features-layer-resolution.sql runOnChange:true
+
+CREATE INDEX IF NOT EXISTS layers_features_layer_resolution_idx
+ON layers_features (
+  layer_id,
+  ((properties ->> 'resolution')::int)
+);

--- a/src/main/resources/db/changelog/v1.19/v1.19.yaml
+++ b/src/main/resources/db/changelog/v1.19/v1.19.yaml
@@ -1,0 +1,5 @@
+## Database Changelog
+databaseChangeLog:
+  - include:
+      relativeToChangelogFile: true
+      file: create-index-layers-features-layer-resolution.sql


### PR DESCRIPTION
## Summary
- add migration v1.19 to create `layers_features_layer_resolution_idx`
- include the new changelog file in master list

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685d208ee3848324b71c065d3259a52e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the database changelog to include new changes for version 1.19.
  * Added a new database index to improve performance on specific queries involving the layers_features table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->